### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/bioshareX/forms.py
+++ b/bioshareX/forms.py
@@ -236,8 +236,13 @@ class SymlinkForm(forms.Form):
             for i in range(len(path_components)):
                 subpath = os.sep.join(path_components[:i + 1])
                 full_path = os.path.join(self.base_directory, subpath)
-                if not os.path.isdir(full_path) and not os.path.exists(base_path):
-                    os.mkdir(full_path)
+                # Ensure the directory to be created is within base_directory
+                normalized_full_path = os.path.realpath(full_path)
+                base_directory_real = os.path.realpath(self.base_directory)
+                if not normalized_full_path.startswith(base_directory_real + os.sep) and normalized_full_path != base_directory_real:
+                    raise forms.ValidationError('Attempted directory creation outside of base directory.')
+                if not os.path.isdir(full_path) and not os.path.exists(full_path):
+                    os.mkdir(normalized_full_path)
                     self.directories_created.append(subpath)
     def create_link(self):
         self.create_subdirectories()


### PR DESCRIPTION
Potential fix for [https://github.com/amschaal/bioshare/security/code-scanning/9](https://github.com/amschaal/bioshare/security/code-scanning/9)

To fix the issue, ensure that all paths created under `create_subdirectories` are guaranteed to remain within the expected root directory (`self.base_directory`). After joining and normalizing the path, add a check so that the normalized absolute path starts with the absolute version of `self.base_directory`. If the check fails, raise a validation error or skip directory creation. 

**Specifically:**  
- In `create_subdirectories`, after computing `full_path`, normalize and make it absolute, then check it starts with the absolute base directory path followed by a path separator ("os.path.join(self.base_directory, '')" or using "os.path.commonpath").
- If the check fails, raise a `ValidationError` or `Exception`.
- Only proceed to create the directory if the path is valid.

You only need to edit the code in `bioshareX/forms.py` within the region implementing `SymlinkForm.create_subdirectories`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
